### PR TITLE
Adding additional adlib screenshot route

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,12 +4,22 @@ const port = process.env.PORT || 3131
 const screenshot = require('./screenshot')
 
 app.get('/', (req, res) => res.status(200).json({ status: 'ok' }))
-
 app.get('/screenshot', (req, res) => {
   var url = req.query.url + "&t=" + req.query.t 
   var preview_type=req.query.preview_type
   ;(async () => {
     const buffer = await screenshot(url,preview_type)
+    res.setHeader('Content-Disposition', 'attachment; filename="screenshot.png"')
+    res.setHeader('Content-Type', 'image/png')
+    res.send(buffer)
+  })()
+})
+
+app.get('/adlibscreenshot', (req, res) => {
+  var ad_id = req.query.id
+  var url = 'https://www.facebook.com/ads/library/?id=' + ad_id 
+  ;(async () => {
+    const buffer = await screenshot(url)
     res.setHeader('Content-Disposition', 'attachment; filename="screenshot.png"')
     res.setHeader('Content-Type', 'image/png')
     res.send(buffer)

--- a/screenshot.js
+++ b/screenshot.js
@@ -1,30 +1,50 @@
 const puppeteer = require("puppeteer");
 
-module.exports = function (url,preview_type) {
+module.exports = function (url,preview_type='') {
   return new Promise((resolve, reject) => {
     (async () => {
       const browser = await puppeteer.launch({
         args: ["--no-sandbox"],
       });
       const page = await browser.newPage();
-
+      await page.setViewport({ width: 1920, height: 1590 });
       await page.goto(url, {
         waitUntil: ["networkidle0", "domcontentloaded"],
       });
 
       await new Promise((resolve) => setTimeout(resolve, 8000));
-      
+
       var padding = 75;
       var left = 0;
       var top = 0;
       var selector =
         "#fb-ad-preview > div > div > div:nth-child(1) > div > div";
-        if(preview_type == "MOBILE_FEED_STANDARD"){
-          selector = "#ad-preview-mobile-feed-standard > div";
-          padding = 20;
-          left = 340;
-        }   
+      if(preview_type == "MOBILE_FEED_STANDARD"){
+        selector = "#ad-preview-mobile-feed-standard > div";
+        padding = 20;
+        left = 340;
+      } 
+        
+      if(!preview_type){ // adlib case
+        await page.keyboard.press(String.fromCharCode(13)) //Pressing enter to clear the pop-up request error modal on facebook ad library
+        
+        const elmHandlerArray = await page.$$('div[stickto="WINDOW"]')
+        const elmHandler = elmHandlerArray[1]
+        const elmHandlerClassName = await page.evaluate(el => el.className,elmHandler)
 
+        selector = 
+          'div[class=' + '"' +elmHandlerClassName + '"] ' + ' ~ div ~div > :nth-child(3)'; 
+        var screenshotElement = await page.$(selector)
+        if(!screenshotElement){
+          selector = 'div[class=' + '"' +elmHandlerClassName + '"] ' + ' ~ div ~div ~div > :nth-child(3)';
+          screenshotElement = await page.$(selector)
+        }
+        if(!screenshotElement){
+          selector = 'div[class=' + '"' +elmHandlerClassName + '"] ' + ' ~div ~ div ~div ~div > :nth-child(3)';      
+        }
+        padding = 0
+      }
+       
       const rect = await page.evaluate((selector) => {
         const element = document.querySelector(selector);
         const { x, y, width, height } = element.getBoundingClientRect();
@@ -35,17 +55,16 @@ module.exports = function (url,preview_type) {
         throw Error(
           `Could not find element that matches selector: ${selector}.`
         );
-
-      await page.setViewport({ width: 1024, height: 800 });
+      
       const buffer = await page.screenshot({
           path: "element.png",
           type: "png",
           clip: {
             x: left !== 0 ? left : rect.left,
             y: top !== 0 ? top : rect.top,
-            width: rect.width + padding ,
+            width: rect.width + padding,
             height: rect.height + padding,
-          },
+          }
         });
     
       await browser.close();


### PR DESCRIPTION
**Summary**
This PR adds a new /adlibscreenshot route to the service, where it handles screenshots of ads from FB ads library such as sample: https://www.facebook.com/ads/library/?id=368857987484546

**Notes**
The solution is quite hacky in a no. of ways,
- The specific reference divs required to detect the final screenshot element only appears at a certain large enough viewport after some extensive testing. Hence, setting the viewport dimension has been shifted to just before visiting the page (as opposed to just before the screenshot) and I have made this viewport just big enough to ensure the reference divs do appear. I have tested this on the original /screenshot endpoint as well to make sure there is no breakage (at least on local).
- Everytime Puppeteer calls the ad library url, FB pops up a modal (see below). The workaround this was to mimick a "Enter" keyboard press, such that the close button is clicked before the screenshot is taken of the element. If this is not done, the screenshot would be grey as it is being backgrounded by this request error modal.
![image](https://user-images.githubusercontent.com/21160516/95421374-f288bf00-096f-11eb-88f2-947ba5ef420a.png)
